### PR TITLE
Handle required properties

### DIFF
--- a/src/FlowSchema.js
+++ b/src/FlowSchema.js
@@ -33,7 +33,7 @@ export class FlowSchema {
   $id: string;
   $flowType: FlowType;
   $flowRef: ?string;
-  $required: ?Array<any>;
+  $required: ?Array<string>;
   $properties: ?{ [key: string]: FlowSchema };
   $enum: ?Array<any>;
   $union: ?Array<FlowSchema>;

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ const processObjectSchema = (flowSchema: FlowSchema, processor: SchemaProcessor)
         processor(fieldFlowSchema),
       );
 
-      if (flowSchema.$required) {
+      if (_.includes(flowSchema.$required, field)) {
         return ast;
       }
 


### PR DESCRIPTION
From the JSON schema "required" spec:
http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.15

> The value of this keyword MUST be an array. This array MUST have at least one element. Elements of this array MUST be strings, and MUST be unique.
> An object instance is valid against this keyword if its property set contains all elements in this keyword's array value.

Thanks for the great module!